### PR TITLE
Render the modules on a separate thread

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-tactile

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-tactile

--- a/src/Controller/MenuController.java
+++ b/src/Controller/MenuController.java
@@ -200,8 +200,9 @@ public class MenuController implements Initializable {
 		if (isNavOpen) {
 			openMenu.fire();
 		}
-		if(this.showNotification.getTranslateY() == 0 && !initialLoad) {
-			TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+		if (this.showNotification.getTranslateY() == 0 && !initialLoad) {
+			TranslateTransition closeNot =
+					new TranslateTransition(new Duration(173), notifications);
 			closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
 			closeNot.play();
 		}
@@ -299,7 +300,7 @@ public class MenuController implements Initializable {
 
 				Label name = new Label(module.getName());
 				name.setTextAlignment(TextAlignment.CENTER);
-	
+
 				// Set left margin for title, which creates padding in case title is very long
 				VBox.setMargin(name, new Insets(0, 0, 0, vbox.getPrefWidth() * 0.04));
 
@@ -314,7 +315,7 @@ public class MenuController implements Initializable {
 				VBox.setMargin(badge, new Insets(0, 0, 0, vbox.getPrefWidth() * 0.17));
 				// Set the badge width to 66% that of vbox
 				badge.setPrefHeight(vbox.getPrefWidth() * 0.66);
-	
+
 				badge.setBackground(new Background(new BackgroundImage(image,
 						BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
 						BackgroundPosition.DEFAULT, new BackgroundSize(BackgroundSize.AUTO,
@@ -368,7 +369,7 @@ public class MenuController implements Initializable {
 					modules.getChildren().add(vbox);
 				});
 				Platform.runLater(addModule);
-	
+
 				// Ensure shadows don't overlap with edge of FlowPane
 				FlowPane.setMargin(vbox, new Insets(
 						screenHeight * 0.033,
@@ -473,11 +474,12 @@ public class MenuController implements Initializable {
 				}
 			};
 			row.setOnMouseClicked(event -> {
-				if(this.isNavOpen) {
+				if (this.isNavOpen) {
 					closeDrawer.fire();
 				}
-				if(this.showNotification.getTranslateY() == 0) {
-					TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+				if (this.showNotification.getTranslateY() == 0) {
+					TranslateTransition closeNot =
+							new TranslateTransition(new Duration(173), notifications);
 					closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
 					closeNot.play();
 				}
@@ -711,11 +713,12 @@ public class MenuController implements Initializable {
 				}
 			};
 			row.setOnMouseClicked(event -> {
-				if(this.isNavOpen) {
+				if (this.isNavOpen) {
 					closeDrawer.fire();
 				}
-				if(this.showNotification.getTranslateY() == 0) {
-					TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+				if (this.showNotification.getTranslateY() == 0) {
+					TranslateTransition closeNot =
+							new TranslateTransition(new Duration(173), notifications);
 					closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
 					closeNot.play();
 				}
@@ -794,11 +797,12 @@ public class MenuController implements Initializable {
 		table.setRowFactory(e -> {
 			TableRow<Module> row = new TableRow<>();
 			row.setOnMouseClicked(event -> {
-				if(this.isNavOpen) {
+				if (this.isNavOpen) {
 					closeDrawer.fire();
 				}
-				if(this.showNotification.getTranslateY() == 0) {
-					TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+				if (this.showNotification.getTranslateY() == 0) {
+					TranslateTransition closeNot =
+							new TranslateTransition(new Duration(173), notifications);
 					closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
 					closeNot.play();
 				}
@@ -1299,8 +1303,9 @@ public class MenuController implements Initializable {
 		// Set nav to close when clicking outside of it
 		this.mainContent.addEventHandler(MouseEvent.MOUSE_PRESSED,
 			e -> {
-				if(this.showNotification.getTranslateY() == 0) {
-					TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+				if (this.showNotification.getTranslateY() == 0) {
+					TranslateTransition closeNot =
+							new TranslateTransition(new Duration(173), notifications);
 					closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
 					closeNot.play();
 				}

--- a/src/Controller/MenuController.java
+++ b/src/Controller/MenuController.java
@@ -1249,10 +1249,9 @@ public class MenuController implements Initializable {
 		// Set nav to close when clicking outside of it
 		this.mainContent.addEventHandler(MouseEvent.MOUSE_PRESSED,
 			e -> {
-				TranslateTransition closeNot =
-						new TranslateTransition(new Duration(173), notifications);
-				closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56));
-				closeNot.play();
+				if(this.showNotification.getTranslateY() == 0) {
+					this.showNotification.fire();
+				}
 
 				if (this.isNavOpen) {
 					this.openMenu.fire();

--- a/src/Controller/MenuController.java
+++ b/src/Controller/MenuController.java
@@ -127,6 +127,7 @@ public class MenuController implements Initializable {
 	private Window current;
 	private boolean isNavOpen;
 	private boolean mouseDown = false;
+	private boolean initialLoad = true;
 
 	// Screen size:
 	private double screenWidth = Screen.getPrimary().getVisualBounds().getWidth();
@@ -199,6 +200,12 @@ public class MenuController implements Initializable {
 		if (isNavOpen) {
 			openMenu.fire();
 		}
+		if(this.showNotification.getTranslateY() == 0 && !initialLoad) {
+			TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+			closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
+			closeNot.play();
+		}
+		initialLoad = false;
 
 		this.updateNotifications();
 		this.updateMenu();
@@ -456,6 +463,15 @@ public class MenuController implements Initializable {
 				}
 			};
 			row.setOnMouseClicked(event -> {
+				if(this.isNavOpen) {
+					closeDrawer.fire();
+				}
+				if(this.showNotification.getTranslateY() == 0) {
+					TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+					closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
+					closeNot.play();
+				}
+
 				if (!row.isEmpty() && event.getButton() == MouseButton.PRIMARY
 						&& event.getClickCount() == 2) {
 					try {
@@ -685,6 +701,15 @@ public class MenuController implements Initializable {
 				}
 			};
 			row.setOnMouseClicked(event -> {
+				if(this.isNavOpen) {
+					closeDrawer.fire();
+				}
+				if(this.showNotification.getTranslateY() == 0) {
+					TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+					closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
+					closeNot.play();
+				}
+
 				if (!row.isEmpty() && event.getButton() == MouseButton.PRIMARY
 						&& event.getClickCount() == 2) {
 					try {
@@ -759,6 +784,15 @@ public class MenuController implements Initializable {
 		table.setRowFactory(e -> {
 			TableRow<Module> row = new TableRow<>();
 			row.setOnMouseClicked(event -> {
+				if(this.isNavOpen) {
+					closeDrawer.fire();
+				}
+				if(this.showNotification.getTranslateY() == 0) {
+					TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+					closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
+					closeNot.play();
+				}
+
 				if (!row.isEmpty() && event.getButton() == MouseButton.PRIMARY
 						&& event.getClickCount() == 2) {
 					this.loadModule(row.getItem(), this.current, null);
@@ -1406,6 +1440,7 @@ public class MenuController implements Initializable {
 			this.isNavOpen = !isNavOpen;
 			if (navList.getTranslateX() != 0) {
 				openNav.play();
+				this.isNavOpen = true;
 			} else {
 				closeNav.setToX(-(navList.getWidth()
 						+ this.navShadowRadius + this.navShadowOffset));

--- a/src/Controller/MenuController.java
+++ b/src/Controller/MenuController.java
@@ -273,6 +273,12 @@ public class MenuController implements Initializable {
 		FlowPane modules = new FlowPane();
 
 		Thread renderModules = new Thread(() -> {
+			Label oldLabel = new Label(this.welcome.getText());
+			Thread sayLoading = new Thread(() -> {
+				this.welcome.setText(this.welcome.getText() + "  LOADING...");
+			});
+			Platform.runLater(sayLoading);
+
 			for (Module module : profile.getModules()) {
 				VBox vbox = new VBox();
 
@@ -370,6 +376,10 @@ public class MenuController implements Initializable {
 						screenHeight * 0.022,
 						screenWidth * 0.037));
 			}
+			Thread removeLoading = new Thread(() -> {
+				this.welcome.setText(oldLabel.getText());
+			});
+			Platform.runLater(removeLoading);
 		});
 		renderModules.start();
 

--- a/src/Controller/MenuController.java
+++ b/src/Controller/MenuController.java
@@ -265,100 +265,106 @@ public class MenuController implements Initializable {
 						true));
 		FlowPane modules = new FlowPane();
 
-		for (Module module : profile.getModules()) {
-			VBox vbox = new VBox();
+		Thread renderModules = new Thread(() -> {
+			for (Module module : profile.getModules()) {
+				VBox vbox = new VBox();
 
-			// Set the width of the module to 15% of the screen resolution
-			if (screenWidth > screenHeight) {
-				vbox.setPrefWidth(screenWidth * 0.14);
-			} else {
-				//If device is in portrait mode, set vbox width based on height
-				vbox.setPrefWidth(screenHeight * 0.14);
-			}
-			// Set the height of the module to 112% of its width
-			vbox.setPrefHeight(vbox.getPrefWidth() * 1.12);
-			// Set margin between text and badge to 10% vbox width
-			vbox.setSpacing(vbox.getPrefWidth() * 0.1);
-
-			vbox.setAlignment(Pos.CENTER);
-			vbox.setCursor(Cursor.HAND);
-
-			Label name = new Label(module.getName());
-			name.setTextAlignment(TextAlignment.CENTER);
-
-			// Set left margin for title, which creates padding in case title is very long
-			VBox.setMargin(name, new Insets(0, 0, 0, vbox.getPrefWidth() * 0.04));
-
-			vbox.getChildren().add(name);
-
-			BufferedImage buff =
-					GanttishDiagram.getBadge(module.calculateProgress(), true, 1);
-			Image image = SwingFXUtils.toFXImage(buff, null);
-			Pane badge = new Pane();
-
-			// Set the distance from left edge to badge 17% of vbox width
-			VBox.setMargin(badge, new Insets(0, 0, 0, vbox.getPrefWidth() * 0.17));
-			// Set the badge width to 66% that of vbox
-			badge.setPrefHeight(vbox.getPrefWidth() * 0.66);
-
-			badge.setBackground(new Background(new BackgroundImage(image,
-					BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
-					BackgroundPosition.DEFAULT, new BackgroundSize(BackgroundSize.AUTO,
-							BackgroundSize.AUTO, false, false, true, false))));
-			vbox.getChildren().add(badge);
-
-			/*
-			 * If mouse clicks on module, depress it.
-			 * If mouse leaves module while depressed, undepress button.
-			 * If mouse re-enters, then re-depress module.
-			 * If mouse is not depressed when it enters module, show hover effect.
-			 */
-			vbox.addEventHandler(MouseEvent.MOUSE_ENTERED, e -> {
-				if (mouseDown) {
-					vbox.setEffect(this.modulePressedShadow);
+				// Set the width of the module to 15% of the screen resolution
+				if (screenWidth > screenHeight) {
+					vbox.setPrefWidth(screenWidth * 0.14);
 				} else {
-					vbox.setEffect(this.moduleHoverShadow);
+					//If device is in portrait mode, set vbox width based on height
+					vbox.setPrefWidth(screenHeight * 0.14);
 				}
-			});
-			vbox.addEventHandler(MouseEvent.MOUSE_EXITED, e -> {
+				// Set the height of the module to 112% of its width
+				vbox.setPrefHeight(vbox.getPrefWidth() * 1.12);
+				// Set margin between text and badge to 10% vbox width
+				vbox.setSpacing(vbox.getPrefWidth() * 0.1);
+
+				vbox.setAlignment(Pos.CENTER);
+				vbox.setCursor(Cursor.HAND);
+
+				Label name = new Label(module.getName());
+				name.setTextAlignment(TextAlignment.CENTER);
+	
+				// Set left margin for title, which creates padding in case title is very long
+				VBox.setMargin(name, new Insets(0, 0, 0, vbox.getPrefWidth() * 0.04));
+
+				vbox.getChildren().add(name);
+
+				BufferedImage buff =
+						GanttishDiagram.getBadge(module.calculateProgress(), true, 1);
+				Image image = SwingFXUtils.toFXImage(buff, null);
+				Pane badge = new Pane();
+
+				// Set the distance from left edge to badge 17% of vbox width
+				VBox.setMargin(badge, new Insets(0, 0, 0, vbox.getPrefWidth() * 0.17));
+				// Set the badge width to 66% that of vbox
+				badge.setPrefHeight(vbox.getPrefWidth() * 0.66);
+	
+				badge.setBackground(new Background(new BackgroundImage(image,
+						BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
+						BackgroundPosition.DEFAULT, new BackgroundSize(BackgroundSize.AUTO,
+								BackgroundSize.AUTO, false, false, true, false))));
+				vbox.getChildren().add(badge);
+
+				/*
+				 * If mouse clicks on module, depress it.
+				 * If mouse leaves module while depressed, undepress button.
+				 * If mouse re-enters, then re-depress module.
+				 * If mouse is not depressed when it enters module, show hover effect.
+				 */
+				vbox.addEventHandler(MouseEvent.MOUSE_ENTERED, e -> {
+					if (mouseDown) {
+						vbox.setEffect(this.modulePressedShadow);
+					} else {
+						vbox.setEffect(this.moduleHoverShadow);
+					}
+				});
+				vbox.addEventHandler(MouseEvent.MOUSE_EXITED, e -> {
+					vbox.setEffect(this.moduleDefaultShadow);
+				});
+
+				vbox.addEventHandler(MouseEvent.MOUSE_PRESSED, e -> {
+					vbox.setEffect(this.modulePressedShadow);
+					mouseDown = true;
+				});
+				vbox.addEventHandler(MouseEvent.MOUSE_RELEASED, e -> {
+					vbox.setEffect(this.moduleDefaultShadow);
+					mouseDown = false;
+				});
+
+				vbox.addEventHandler(MouseEvent.MOUSE_CLICKED, e ->
+					module.open(this.current));
+
+				vbox.setOnTouchPressed(new EventHandler<TouchEvent>() {
+					@Override public void handle(TouchEvent event) {
+						vbox.setEffect(modulePressedShadow);
+					}
+				});
+				vbox.setOnTouchReleased(new EventHandler<TouchEvent>() {
+					@Override public void handle(TouchEvent event) {
+						vbox.setEffect(moduleDefaultShadow);
+					}
+				});
+
 				vbox.setEffect(this.moduleDefaultShadow);
-			});
+				vbox.setStyle("-fx-background-color: white");
 
-			vbox.addEventHandler(MouseEvent.MOUSE_PRESSED, e -> {
-				vbox.setEffect(this.modulePressedShadow);
-				mouseDown = true;
-			});
-			vbox.addEventHandler(MouseEvent.MOUSE_RELEASED, e -> {
-				vbox.setEffect(this.moduleDefaultShadow);
-				mouseDown = false;
-			});
-
-			vbox.addEventHandler(MouseEvent.MOUSE_CLICKED, e ->
-				module.open(this.current));
-
-			vbox.setOnTouchPressed(new EventHandler<TouchEvent>() {
-				@Override public void handle(TouchEvent event) {
-					vbox.setEffect(modulePressedShadow);
-				}
-			});
-			vbox.setOnTouchReleased(new EventHandler<TouchEvent>() {
-				@Override public void handle(TouchEvent event) {
-					vbox.setEffect(moduleDefaultShadow);
-				}
-			});
-
-			vbox.setEffect(this.moduleDefaultShadow);
-			vbox.setStyle("-fx-background-color: white");
-
-			modules.getChildren().add(vbox);
-
-			// Ensure shadows don't overlap with edge of FlowPane
-			FlowPane.setMargin(vbox, new Insets(
-					screenHeight * 0.033,
-					0,
-					screenHeight * 0.022,
-					screenWidth * 0.037));
-		}
+				Thread addModule = new Thread(() -> {
+					modules.getChildren().add(vbox);
+				});
+				Platform.runLater(addModule);
+	
+				// Ensure shadows don't overlap with edge of FlowPane
+				FlowPane.setMargin(vbox, new Insets(
+						screenHeight * 0.033,
+						0,
+						screenHeight * 0.022,
+						screenWidth * 0.037));
+			}
+		});
+		renderModules.start();
 
 		/*
 		 * Allow modules to be scrollable if window is too small to display them

--- a/src/Controller/MenuController.java
+++ b/src/Controller/MenuController.java
@@ -1250,7 +1250,9 @@ public class MenuController implements Initializable {
 		this.mainContent.addEventHandler(MouseEvent.MOUSE_PRESSED,
 			e -> {
 				if(this.showNotification.getTranslateY() == 0) {
-					this.showNotification.fire();
+					TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
+					closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
+					closeNot.play();
 				}
 
 				if (this.isNavOpen) {
@@ -1406,14 +1408,14 @@ public class MenuController implements Initializable {
 		});
 
 		TranslateTransition openNot = new TranslateTransition(new Duration(222), notifications);
-		openNot.setToY(0);
+		openNot.setToY(17);
 		TranslateTransition closeNot = new TranslateTransition(new Duration(173), notifications);
 
 		showNotification.setOnAction((ActionEvent e1) -> {
-			if (notifications.getTranslateY() != 0) {
+			if (notifications.getTranslateY() != 17) {
 				openNot.play();
 			} else {
-				closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56));
+				closeNot.setToY(-(notifications.getHeight() + this.navShadowRadius + 56 + 17));
 				closeNot.play();
 			}
 		});


### PR DESCRIPTION
This pull request makes a very significant change to the way the application handles rendering the modules.
The modules on the dashboard were previously rendered on the main thread. This would cause the GUI to be unresponsive while those were rendering. This wasn't particularly noticeable with a small number of modules. However, when there are a lot of modules, this is very much noticeable.
Now, the dashboard loads, and then the modules load in sequence. afterwards.

Startup time of the application has been improved quite significantly as well.

Also, the hamburger menu and notification shade automatically close more often, including when clicking within a table, as well as opening a different activity (IE switching from Dashboard to Modules). This further enhances original fixes for #57.

This pull requests technically fixes #131.