### PR TITLE
Removed RaiderPlanner-master.zip and fixed links

### DIFF
--- a/docs/download.html
+++ b/docs/download.html
@@ -63,7 +63,7 @@
         <div class="row align-items-center">
           <div class="col-md-6 order-2">
             <div class="p-5">
-            <a href="https://github.com/rsanchez-wsu/RaiderPlanner/raw/master/docs/RaiderPlanner-master.zip" download="RaiderPlanner-master.zip">
+            <a href="https://github.com/rsanchez-wsu/RaiderPlanner/">
               <img src="images/download.png" alt="" style="width:80%; height:10%; ">
             </a>
             </div>
@@ -71,7 +71,7 @@
           <div class="col-md-6 order-1">
             <div class="p-5">
               <h2 class="display-3">Getting started:</h2>
-              <p>1. <a href="https://github.com/rsanchez-wsu/RaiderPlanner/raw/master/docs/RaiderPlanner-master.zip" download="RaiderPlanner-master.zip">Download the file.</a> This link is not a working link right now.</p>
+              <p>1. <a href="https://github.com/rsanchez-wsu/RaiderPlanner/">Download the file.</a></p>
               <p>2. Extract the file into your desired location.</p>
               <p>3. Start up Eclipse and import your file.</p>
               <p>4. Run RaiderPlanner.git to start up the program.</p>


### PR DESCRIPTION
Removed RaiderPlanner-master.zip.
Changed links to RaiderPlanner-master.zip to GitHub repository URL.

Fixes #163 