### PR TITLE
ref #9 The imports for StudyPlanner are in lexicographical order

### DIFF
--- a/src/Model/StudyPlanner.java
+++ b/src/Model/StudyPlanner.java
@@ -21,12 +21,13 @@
 
 package Model;
 
-import javax.crypto.NoSuchPaddingException;
+
 import java.io.Serializable;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.NoSuchPaddingException;
 import View.UIManager;
 
 /**


### PR DESCRIPTION
ref #9 This fixes the checkstyle issue by placing the imports for StudyPlanner in lexicographical order.