### PR TITLE
First pass on issue #224: Make ModelEntity and ModelEntity.open() abstract

### DIFF
--- a/src/edu/wright/cs/raiderplanner/model/Assignment.java
+++ b/src/edu/wright/cs/raiderplanner/model/Assignment.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
  * PearPlanner/RaiderPlanner.
  * Created by Team BRONZE on 4/27/17
  */
-public class Assignment extends VersionControlEntity {
+public abstract class Assignment extends VersionControlEntity {
 	protected ArrayList<Task> tasks = new ArrayList<>();
 	protected ArrayList<Requirement> requirements = new ArrayList<>();
 	protected int weighting;

--- a/src/edu/wright/cs/raiderplanner/model/Building.java
+++ b/src/edu/wright/cs/raiderplanner/model/Building.java
@@ -21,6 +21,8 @@
 
 package edu.wright.cs.raiderplanner.model;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
+
 /**
  * PearPlanner/RaiderPlanner.
  * Created by Team BRONZE on 4/27/17
@@ -90,6 +92,15 @@ public class Building extends VersionControlEntity {
 	public String toString() {
 		return code + " " + name + " ( " + Double.toString(latitude)
 				+ " , " + Double.toString(longitude) + " )";
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 }
 

--- a/src/edu/wright/cs/raiderplanner/model/Deadline.java
+++ b/src/edu/wright/cs/raiderplanner/model/Deadline.java
@@ -21,6 +21,8 @@
 
 package edu.wright.cs.raiderplanner.model;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
+
 /**
  * PearPlanner/RaiderPlanner.
  * Created by Team BRONZE on 4/27/17
@@ -29,5 +31,14 @@ public class Deadline extends Event {
 	// maybe we can get rid of this
 	public Deadline(String cdate) {
 		super(cdate);
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/edu/wright/cs/raiderplanner/model/Event.java
+++ b/src/edu/wright/cs/raiderplanner/model/Event.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
  * Using FastDateFormat because it is threadsafe.
  * @author Andrew Odintsov
  */
-public class Event extends VersionControlEntity {
+public abstract class Event extends VersionControlEntity {
 
 	private static final long serialVersionUID = 4940549364156632405L;
 

--- a/src/edu/wright/cs/raiderplanner/model/Event.java
+++ b/src/edu/wright/cs/raiderplanner/model/Event.java
@@ -24,6 +24,8 @@ package edu.wright.cs.raiderplanner.model;
 
 import org.apache.commons.lang3.time.FastDateFormat;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
+
 import java.text.ParseException;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -34,7 +36,7 @@ import java.util.regex.Pattern;
  * Using FastDateFormat because it is threadsafe.
  * @author Andrew Odintsov
  */
-public abstract class Event extends VersionControlEntity {
+public class Event extends VersionControlEntity {
 
 	private static final long serialVersionUID = 4940549364156632405L;
 
@@ -125,5 +127,14 @@ public abstract class Event extends VersionControlEntity {
 	@Override
 	public String toString() {
 		return this.date.getTime().toString();
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/edu/wright/cs/raiderplanner/model/ExamEvent.java
+++ b/src/edu/wright/cs/raiderplanner/model/ExamEvent.java
@@ -23,6 +23,8 @@ package edu.wright.cs.raiderplanner.model;
 
 import java.text.SimpleDateFormat;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
+
 /**
  * An exam event with a location/room and a duration.
  *
@@ -76,6 +78,15 @@ public class ExamEvent extends Event {
 	 */
 	public Room getRoom() {
 		return room;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 
 }

--- a/src/edu/wright/cs/raiderplanner/model/Extension.java
+++ b/src/edu/wright/cs/raiderplanner/model/Extension.java
@@ -21,6 +21,8 @@
 
 package edu.wright.cs.raiderplanner.model;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
+
 /**
  * PearPlanner/RaiderPlanner.
  * Created by Team BRONZE on 4/27/17
@@ -79,6 +81,15 @@ public class Extension extends VersionControlEntity {
 	public void setApprovalStatus(ApprovalStatus newApprovalStatus) {
 		// initial set up code below - check if this needs updating
 		approvalStatus = newApprovalStatus;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 
 	// constructor

--- a/src/edu/wright/cs/raiderplanner/model/Milestone.java
+++ b/src/edu/wright/cs/raiderplanner/model/Milestone.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
+
 /**
  * PearPlanner/RaiderPlanner.
  * Created by Team BRONZE on 4/27/17
@@ -232,6 +234,15 @@ public class Milestone extends ModelEntity {
 	public void setDeadline(LocalDate date) {
 		this.deadline.setDate(date.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
 				+ "T00:00:01Z");
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 
 }

--- a/src/edu/wright/cs/raiderplanner/model/ModelEntity.java
+++ b/src/edu/wright/cs/raiderplanner/model/ModelEntity.java
@@ -31,7 +31,7 @@ import java.util.List;
  * PearPlanner/RaiderPlanner.
  * Created by Team BRONZE on 4/27/17
  */
-public class ModelEntity implements Serializable {
+public abstract class ModelEntity implements Serializable {
 	protected String name = "";
 	protected MultilineString details = null;
 	protected ArrayList<Note> notes;
@@ -177,8 +177,8 @@ public class ModelEntity implements Serializable {
 	/**
 	 * Open the appropriate UI window for this class
 	 * To be overridden by children.
+	 * @return 
 	 */
-	public void open(MenuController.Window current) {
-	}
+	public abstract void open(MenuController.Window current);
 
 }

--- a/src/edu/wright/cs/raiderplanner/model/Person.java
+++ b/src/edu/wright/cs/raiderplanner/model/Person.java
@@ -23,6 +23,8 @@ package edu.wright.cs.raiderplanner.model;
 
 import org.apache.commons.validator.routines.EmailValidator;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.regex.Pattern;
@@ -344,6 +346,15 @@ public class Person extends VersionControlEntity {
 	@Override
 	public String toString() {
 		return getFullName() + " ( " + getEmail() + " )";
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 
 }

--- a/src/edu/wright/cs/raiderplanner/model/QuantityType.java
+++ b/src/edu/wright/cs/raiderplanner/model/QuantityType.java
@@ -24,6 +24,7 @@ package edu.wright.cs.raiderplanner.model;
 import java.util.ArrayList;
 
 import edu.wright.cs.raiderplanner.controller.MainController;
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
 
 /**
  * PearPlanner/RaiderPlanner.
@@ -244,4 +245,13 @@ public class QuantityType extends ModelEntity {
 	}
 
 	public static QuantityType DEFAULT = quantityDatabase.get(0);
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
+	}
 }

--- a/src/edu/wright/cs/raiderplanner/model/Room.java
+++ b/src/edu/wright/cs/raiderplanner/model/Room.java
@@ -21,6 +21,7 @@
 
 package edu.wright.cs.raiderplanner.model;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
 
 /**
  * PearPlanner/RaiderPlanner.
@@ -87,5 +88,14 @@ public class Room extends VersionControlEntity {
 
 	public Room(String cRoomNumber) {
 		setRoomNumber(cRoomNumber);
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/edu/wright/cs/raiderplanner/model/TaskType.java
+++ b/src/edu/wright/cs/raiderplanner/model/TaskType.java
@@ -22,6 +22,7 @@
 package edu.wright.cs.raiderplanner.model;
 
 import edu.wright.cs.raiderplanner.controller.MainController;
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
 
 import java.util.ArrayList;
 
@@ -227,4 +228,13 @@ public class TaskType extends ModelEntity {
 	}
 
 	public static TaskType DEFAULT = taskDatabase.get(0);
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
+	}
 }

--- a/src/edu/wright/cs/raiderplanner/model/TimeTableEventType.java
+++ b/src/edu/wright/cs/raiderplanner/model/TimeTableEventType.java
@@ -21,6 +21,8 @@
 
 package edu.wright.cs.raiderplanner.model;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
+
 /**
  * PearPlanner/RaiderPlanner.
  * Created by Team BRONZE on 4/27/17
@@ -28,5 +30,14 @@ package edu.wright.cs.raiderplanner.model;
 public class TimeTableEventType extends VersionControlEntity {
 	public String toString() {
 		return name;
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/edu/wright/cs/raiderplanner/model/TimetableEvent.java
+++ b/src/edu/wright/cs/raiderplanner/model/TimetableEvent.java
@@ -21,6 +21,7 @@
 
 package edu.wright.cs.raiderplanner.model;
 
+import edu.wright.cs.raiderplanner.controller.MenuController.Window;
 
 /**
  * PearPlanner/RaiderPlanner.
@@ -133,6 +134,15 @@ public class TimetableEvent extends Event {
 	@Override
 	public String toString() {
 		return name + " in " + room.toString() + " at " + date.getTime();
+	}
+
+	/* (non-Javadoc)
+	 * @see edu.wright.cs.raiderplanner.model.ModelEntity#open(edu.wright.cs.raiderplanner.controller.MenuController.Window)
+	 */
+	@Override
+	public void open(Window current) {
+		// TODO Auto-generated method stub
+		
 	}
 
 }

--- a/src/edu/wright/cs/raiderplanner/model/VersionControlEntity.java
+++ b/src/edu/wright/cs/raiderplanner/model/VersionControlEntity.java
@@ -29,7 +29,7 @@ import edu.wright.cs.raiderplanner.controller.MainController;
  * PearPlanner/RaiderPlanner.
  * Created by Team BRONZE on 4/27/17
  */
-public class VersionControlEntity extends ModelEntity {
+public abstract class VersionControlEntity extends ModelEntity {
 	protected int version;
 	protected String uid;
 	protected boolean sealed;

--- a/test/edu/wright/cs/raiderplanner/model/AssignmentTest.java
+++ b/test/edu/wright/cs/raiderplanner/model/AssignmentTest.java
@@ -37,6 +37,7 @@ public class AssignmentTest {
 	Assignment assignment;
 	Person person1;
 	Person person2;
+	ExamEvent cTimeSlot;
 
 	/**
 	 * This test case creates two Person objects and an Assignment object for use in
@@ -47,7 +48,7 @@ public class AssignmentTest {
 	public void setUp() throws Exception {
 		person1 = new Person("Dr.", "Mark Fisher", true);
 		person2 = new Person("Dr.", "Steven Laycock", true);
-		assignment = new Assignment(30, person1, person1, person2, 100);
+		assignment = new Exam(2, person1, person2, person1, 4, cTimeSlot);
 	}
 
 	/**

--- a/test/edu/wright/cs/raiderplanner/model/ModelEntityTest.java
+++ b/test/edu/wright/cs/raiderplanner/model/ModelEntityTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 
@@ -62,7 +63,7 @@ public class ModelEntityTest {
 		note = new Note("Note1", gregorianCalendar, multilineString);
 		notes = new ArrayList<>();
 		notes.add(note);
-		modelEntity = new ModelEntity("name1", detailsArray, notes);
+		modelEntity = new Milestone("Milestone", "Test", LocalDate.of(2018, 2, 4));
 	}
 
 	/**

--- a/test/edu/wright/cs/raiderplanner/model/VersionControlEntityTest.java
+++ b/test/edu/wright/cs/raiderplanner/model/VersionControlEntityTest.java
@@ -42,7 +42,8 @@ import org.testfx.framework.junit.ApplicationTest;
 @Disabled
 public class VersionControlEntityTest extends ApplicationTest {
 
-	VersionControlEntity versionControlEntity = new VersionControlEntity();
+	VersionControlEntity versionControlEntity;
+	ExamEvent examEvent;
 
 	/**
 	 * This test case create a new instance of the VersionControlEntity.
@@ -50,7 +51,8 @@ public class VersionControlEntityTest extends ApplicationTest {
 	 */
 	@BeforeEach
 	public void setUp() throws Exception {
-		versionControlEntity = new VersionControlEntity();
+		Person person = new Person("Mr.", "Greene", true);
+		versionControlEntity = new Exam(4, person, person, person, 4, examEvent);
 	}
 
 


### PR DESCRIPTION
As commented on previously within the issue referenced (#224), I've made ModelEntity and the appropriate subclasses abstract. I've also refactored the accompanying unit tests accordingly, so they will still compile and pass.