### PR TITLE
Add functionality for removing a taskType

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,7 +31,9 @@ Amila Dias <asdtech153@live.com>
 Katherine Lemmert <katlemmert001@gmail.com>
 Nathan Schroer <schroer.14@wright.edu>
 Hayden Richter <richter.20@wright.edu>
+Joshua Shaw <shaw.150@wright.edu>
 Ian Smith <smith.1903@wright.edu>
 Jacob Smith <smith.2198@wright.edu>
 Clayton D. Terrill <terrill.22@wright.edu>
+Alexander Voultos <voultos.2@wright.com>
 Sara Walsh <uglypurses@yahoo.com>

--- a/src/edu/wright/cs/raiderplanner/controller/TaskController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/TaskController.java
@@ -71,6 +71,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.ResourceBundle;
 
 /**
@@ -107,6 +108,7 @@ public class TaskController implements Initializable {
 	@FXML private Button removeDep;
 	@FXML private ToggleButton markComplete;
 	@FXML private Button addTaskType;
+	@FXML private Button removeTaskType;
 	@FXML private MenuItem taskTypeMenu;
 
 	// Panes:
@@ -272,6 +274,23 @@ public class TaskController implements Initializable {
 		this.taskTypeName.clear();
 		this.taskTypeMenu.setDisable(true);
 	}
+	/**
+	 * Add a new TaskType.
+	 */
+	public void removeTaskType() {
+		int doom = this.taskType.getSelectionModel().getSelectedIndex();
+		this.taskType.getItems().remove(doom);
+	    ArrayList <TaskType> temp = TaskType.getTaskDatabase();
+	    temp.remove(doom);
+	    TaskType.setTaskDatabase(temp);
+		// Update the current list:
+		this.taskType.getItems().clear();
+		this.taskType.getItems().addAll(TaskType.listOfNames());
+		this.taskType.getSelectionModel().select(task.getName());
+		// =================
+	}
+
+	
 
 	/**
 	 * Submit the form and create a new Task.
@@ -389,6 +408,10 @@ public class TaskController implements Initializable {
 			if (event.isPrimaryButtonDown()) {
 				context.show(addTaskType, event.getScreenX(), event.getScreenY());
 			}
+		});
+		
+		this.removeTaskType.setOnMousePressed(event -> {
+			removeTaskType();
 		});
 		// =================
 

--- a/src/edu/wright/cs/raiderplanner/controller/TaskController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/TaskController.java
@@ -274,23 +274,22 @@ public class TaskController implements Initializable {
 		this.taskTypeName.clear();
 		this.taskTypeMenu.setDisable(true);
 	}
+
 	/**
 	 * Add a new TaskType.
 	 */
 	public void removeTaskType() {
 		int doom = this.taskType.getSelectionModel().getSelectedIndex();
 		this.taskType.getItems().remove(doom);
-	    ArrayList <TaskType> temp = TaskType.getTaskDatabase();
-	    temp.remove(doom);
-	    TaskType.setTaskDatabase(temp);
+		ArrayList<TaskType> temp = TaskType.getTaskDatabase();
+		temp.remove(doom);
+		TaskType.setTaskDatabase(temp);
 		// Update the current list:
 		this.taskType.getItems().clear();
 		this.taskType.getItems().addAll(TaskType.listOfNames());
 		this.taskType.getSelectionModel().select(task.getName());
 		// =================
 	}
-
-	
 
 	/**
 	 * Submit the form and create a new Task.

--- a/src/edu/wright/cs/raiderplanner/model/TaskType.java
+++ b/src/edu/wright/cs/raiderplanner/model/TaskType.java
@@ -30,6 +30,22 @@ import java.util.ArrayList;
  * PearPlanner/RaiderPlanner Created by Team BRONZE on 4/27/17.
  */
 public class TaskType extends ModelEntity {
+	/**
+	 * @return the taskDatabase
+	 */
+	public static ArrayList<TaskType> getTaskDatabase() {
+		return taskDatabase;
+	}
+
+	/**
+	 * @param taskDatabase the taskDatabase to set
+	 */
+	public static void setTaskDatabase(ArrayList<TaskType> taskDatabase) {
+		TaskType.taskDatabase = taskDatabase;
+	}
+
+
+
 	private static ArrayList<TaskType> taskDatabase = new ArrayList<>();
 
 	/**

--- a/src/edu/wright/cs/raiderplanner/model/TaskType.java
+++ b/src/edu/wright/cs/raiderplanner/model/TaskType.java
@@ -31,25 +31,13 @@ import java.util.ArrayList;
  */
 public class TaskType extends ModelEntity {
 	/**
-	 * @return the taskDatabase
+	 * the taskDatabase.
 	 */
-	public static ArrayList<TaskType> getTaskDatabase() {
-		return taskDatabase;
-	}
-
-	/**
-	 * @param taskDatabase the taskDatabase to set
-	 */
-	public static void setTaskDatabase(ArrayList<TaskType> taskDatabase) {
-		TaskType.taskDatabase = taskDatabase;
-	}
-
-
 
 	private static ArrayList<TaskType> taskDatabase = new ArrayList<>();
 
 	/**
-	 * @return Returns a array of names of the tasks in the taskDatabase ArrayList.
+	 * Returns a array of names of the tasks in the taskDatabase ArrayList.
 	 */
 	public static String[] listOfNames() {
 		String[] str = new String[taskDatabase.size()];
@@ -223,6 +211,17 @@ public class TaskType extends ModelEntity {
 			taskDatabase.add(this);
 		}
 	}
+	
+	public static ArrayList<TaskType> getTaskDatabase() {
+		return taskDatabase;
+	}
+
+	/**
+	 * taskDatabase the taskDatabase to set.
+	 */
+	public static void setTaskDatabase(ArrayList<TaskType> taskDatabase) {
+		TaskType.taskDatabase = taskDatabase;
+	}
 
 	@Override
 	public boolean equals(Object obj) {
@@ -233,6 +232,7 @@ public class TaskType extends ModelEntity {
 			return false;
 		}
 	}
+	
 
 	/**
 	 * Equals method that takes a String instead of an object. Only checks against name

--- a/src/edu/wright/cs/raiderplanner/model/TaskType.java
+++ b/src/edu/wright/cs/raiderplanner/model/TaskType.java
@@ -50,7 +50,7 @@ public class TaskType extends ModelEntity {
 	}
 
 	/**
-	 * @return Returns a array of task types of the tasks in the taskDatabase ArrayList.
+	 * Returns a array of task types of the tasks in the taskDatabase ArrayList.
 	 */
 	public static TaskType[] listOfTaskTypes() {
 		TaskType[] taskTypes = new TaskType[taskDatabase.size()];
@@ -211,7 +211,10 @@ public class TaskType extends ModelEntity {
 			taskDatabase.add(this);
 		}
 	}
-	
+
+	/**
+	 * Constructor for TaskType.
+	 */
 	public static ArrayList<TaskType> getTaskDatabase() {
 		return taskDatabase;
 	}
@@ -232,7 +235,7 @@ public class TaskType extends ModelEntity {
 			return false;
 		}
 	}
-	
+
 
 	/**
 	 * Equals method that takes a String instead of an object. Only checks against name

--- a/src/edu/wright/cs/raiderplanner/view/Task.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/Task.fxml
@@ -86,6 +86,8 @@
                         </items>
                     </ContextMenu>
                 </Button>
+                 <Button fx:id="removeTaskType" alignment="CENTER" contentDisplay="CENTER" mnemonicParsing="false" text="-">
+                 </Button>
             </children>
             <GridPane.margin>
                 <Insets left="10.0" right="10.0"/>


### PR DESCRIPTION
Users that worked on this project:
Alexander Voultos
Joshua Shaw

Users were previously only able to add taskTypes, not remove them. This
means that users would be stuck with any incorrectly input or otherwise
unwanted taskTypes. The new button located next to the add button will remove whatever item is selected from the drop down menu.

<img width="419" alt="gui1" src="https://user-images.githubusercontent.com/32073367/45787323-bc6e2a80-bc42-11e8-9157-3ffdfb57d708.PNG">
<img width="577" alt="pre" src="https://user-images.githubusercontent.com/32073367/45787331-c4c66580-bc42-11e8-8820-1e93ac2ac7b6.png">
<img width="411" alt="post" src="https://user-images.githubusercontent.com/32073367/45787329-c4c66580-bc42-11e8-930f-57e1e2b7a5f4.png">



