### PR TITLE
Updated Findbugs to Spotbugs, launch4j repository, Gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@
  */
 
 import org.gradle.plugins.ide.eclipse.model.Container
-import org.gradle.plugins.ide.eclipse.model.AccessRule
+
 /**
  * The application plugin facilitates creating an executable JVM application.
  */
@@ -47,7 +47,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'com.github.spotbugs'
 apply plugin: 'edu.sc.seis.launch4j'
 apply plugin: 'org.junit.platform.gradle.plugin'
-apply from: 'https://dl.bintray.com/content/shemnon/javafx-gradle/8.1.1/javafx.plugin'
+
 
 compileJava {
 	sourceCompatibility = JavaVersion.VERSION_1_8
@@ -179,18 +179,6 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
 	}
 	ignoreFailures = true
 }
-/** JavaFx dependency access rules so spotbugs can pick them up **/
-eclipse {
-	classpath {
-		file {
-	    	whenMerged {
-	        	def jre = entries.find { it.path.contains 'org.eclipse.jdt.launching.JRE_CONTAINER' }
-	            jre.accessRules.add(new AccessRule('0', 'javafx/**'))
-	            }
-	        }
-	 }
-}
-
 /**
  * Keep Gradle from rewriting the generic default JRE container configuration
  */

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ import org.gradle.plugins.ide.eclipse.model.AccessRule
  */
 buildscript {
 	repositories {
+	maven {
+		url 'https://plugins.gradle.org/m2/'
+		}
 		mavenLocal()
 		mavenCentral()
 		jcenter()
@@ -33,6 +36,7 @@ buildscript {
 	dependencies {
 		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
 		classpath 'edu.sc.seis.gradle:launch4j:2.4.2'
+		classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.3"
 	}
 }
 
@@ -40,7 +44,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'application'
 apply plugin: 'checkstyle'
-apply plugin: 'findbugs'
+apply plugin: 'com.github.spotbugs'
 apply plugin: 'edu.sc.seis.launch4j'
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply from: 'https://dl.bintray.com/content/shemnon/javafx-gradle/8.1.1/javafx.plugin'
@@ -167,7 +171,7 @@ checkstyle {
 	maxWarnings = 50
 }
 
-tasks.withType(FindBugs) {
+tasks.withType(com.github.spotbugs.SpotBugsTask) {
 	reports {
 		xml.enabled false
 		html.enabled true

--- a/build.gradle
+++ b/build.gradle
@@ -181,14 +181,14 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
 }
 /** JavaFx dependency access rules so spotbugs can pick them up **/
 eclipse {
-	    classpath {
-	        file {
-	            whenMerged {
-	                def jre = entries.find { it.path.contains 'org.eclipse.jdt.launching.JRE_CONTAINER' }
-	                jre.accessRules.add(new AccessRule('0', 'javafx/**'))
+	classpath {
+		file {
+	    	whenMerged {
+	        	def jre = entries.find { it.path.contains 'org.eclipse.jdt.launching.JRE_CONTAINER' }
+	            jre.accessRules.add(new AccessRule('0', 'javafx/**'))
 	            }
 	        }
-	    }
+	 }
 }
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@
  */
 
 import org.gradle.plugins.ide.eclipse.model.Container
-
+import org.gradle.plugins.ide.eclipse.model.AccessRule
 /**
  * The application plugin facilitates creating an executable JVM application.
  */
@@ -43,6 +43,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'findbugs'
 apply plugin: 'edu.sc.seis.launch4j'
 apply plugin: 'org.junit.platform.gradle.plugin'
+apply from: 'https://dl.bintray.com/content/shemnon/javafx-gradle/8.1.1/javafx.plugin'
 
 compileJava {
 	sourceCompatibility = JavaVersion.VERSION_1_8
@@ -173,6 +174,17 @@ tasks.withType(FindBugs) {
 		// html.stylesheet resources.text.fromFile( 'config/xsl/findbugs-custom.xsl' )
 	}
 	ignoreFailures = true
+}
+/** JavaFx dependency access rules so spotbugs can pick them up **/
+eclipse {
+	    classpath {
+	        file {
+	            whenMerged {
+	                def jre = entries.find { it.path.contains 'org.eclipse.jdt.launching.JRE_CONTAINER' }
+	                jre.accessRules.add(new AccessRule('0', 'javafx/**'))
+	            }
+	        }
+	    }
 }
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
-		classpath 'edu.sc.seis.gradle:launch4j:2.4.2'
+		classpath 'gradle.plugin.edu.sc.seis.gradle:launch4j:2.4.4'
 		classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.3"
 	}
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-4.10.2-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip


### PR DESCRIPTION
Findbugs plugin has been replaced/updated with Spotbugs(formerly Findbugs).
Plugin used for Javafx access rules is old, will need to find an alternative when upgrading the wrapper to a newer version. Plan on researching this one more and implementing for a future pull request: https://github.com/javafx-maven-plugin/javafx-maven-plugin

https://www.youtube.com/watch?v=zHb3pb6scRs Information I used to find out about the plugin I implemented in the build.gradle file for Javafx dependency allowance.(Does not work now)

https://plugins.gradle.org/plugin/com.github.spotbugs Found updated information on Spotbugs.
https://plugins.gradle.org/plugin/edu.sc.seis.launch4j  When performing ./gradlew it was failing because of not being able to find the repository for this plugin, it's been updated and is successful.