### PR TITLE
Fix issue 318: add keyboard functionality on account creation screen

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
-        <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="src" output="bin/main" path="src">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="bin/test" path="test">
+		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/src/edu/wright/cs/raiderplanner/controller/AccountController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/AccountController.java
@@ -214,44 +214,42 @@ public class AccountController implements Initializable {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Used for toggleButton Functionality.
-	 * @return opposite toggle
 	 */
-	
+
 	public void toggleButton() {
-		if(famLast.isSelected() == true) {
+		if (famLast.isSelected() == true) {
 			famLast.setSelected(false);
-		}
-		else if(famLast.isSelected() == false) {
+		} else if (famLast.isSelected() == false) {
 			famLast.setSelected(true);
 		}
 	}
-	 EventHandler<ActionEvent> event = new EventHandler<ActionEvent>() { 
-         public void handle(ActionEvent e) 
-         { 
-             if (famLast.isSelected() && famLast.isFocused()) {
+
+	EventHandler<ActionEvent> event = new EventHandler<ActionEvent>() {
+		public void handle(ActionEvent eq) {
+			if (famLast.isSelected() && famLast.isFocused()) {
 				famLast.setSelected(false);
-			} else if(famLast.isSelected() == false && famLast.isFocused()) {
+			} else if (famLast.isSelected() == false && famLast.isFocused()) {
 				famLast.setSelected(true);
 			}
-         }
-	 }; 
-     
+		}
+	};
+
 	@Override
 	public void initialize(URL location, ResourceBundle resources) {
 		Platform.runLater(() -> this.pane.requestFocus());
 		submit.defaultButtonProperty().bind(submit.focusedProperty());
 		cancelButton.defaultButtonProperty().bind(cancelButton.focusedProperty());
 		submit.setOnAction(e -> {
-			if(submit.isFocused()) {
-			handleSubmit();
+			if (submit.isFocused()) {
+				handleSubmit();
 			}
-			});
-		cancelButton.setOnAction(b -> {   
-			if(cancelButton.isFocused()) {
-		      System.exit(0);
+		});
+		cancelButton.setOnAction(b -> {
+			if (cancelButton.isFocused()) {
+				System.exit(0);
 			}
 		});
 	}

--- a/src/edu/wright/cs/raiderplanner/controller/AccountController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/AccountController.java
@@ -24,6 +24,8 @@ package edu.wright.cs.raiderplanner.controller;
 import edu.wright.cs.raiderplanner.model.Account;
 import edu.wright.cs.raiderplanner.model.Person;
 import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Alert;
@@ -54,13 +56,13 @@ public class AccountController implements Initializable {
 	@FXML private TextField email;
 	@FXML private CheckBox famLast;
 	@FXML private Button submit;
+	@FXML private Button cancelButton;
 	@FXML private GridPane pane;
 	@FXML private Alert invalidInputAlert = new Alert(AlertType.ERROR);
 	@FXML private Alert emptyNameAlert = new Alert(AlertType.CONFIRMATION);
 
 	private Account account;
 	private boolean success = false;
-
 	/**
 	 * Returns the Account object being managed by this controller.
 	 *
@@ -212,9 +214,45 @@ public class AccountController implements Initializable {
 			return false;
 		}
 	}
-
+	
+	/**
+	 * Used for toggleButton Functionality.
+	 * @return opposite toggle
+	 */
+	
+	public void toggleButton() {
+		if(famLast.isSelected() == true) {
+			famLast.setSelected(false);
+		}
+		else if(famLast.isSelected() == false) {
+			famLast.setSelected(true);
+		}
+	}
+	 EventHandler<ActionEvent> event = new EventHandler<ActionEvent>() { 
+         public void handle(ActionEvent e) 
+         { 
+             if (famLast.isSelected() && famLast.isFocused()) {
+				famLast.setSelected(false);
+			} else if(famLast.isSelected() == false && famLast.isFocused()) {
+				famLast.setSelected(true);
+			}
+         }
+	 }; 
+     
 	@Override
 	public void initialize(URL location, ResourceBundle resources) {
 		Platform.runLater(() -> this.pane.requestFocus());
+		submit.defaultButtonProperty().bind(submit.focusedProperty());
+		cancelButton.defaultButtonProperty().bind(cancelButton.focusedProperty());
+		submit.setOnAction(e -> {
+			if(submit.isFocused()) {
+			handleSubmit();
+			}
+			});
+		cancelButton.setOnAction(b -> {   
+			if(cancelButton.isFocused()) {
+		      System.exit(0);
+			}
+		});
 	}
 }

--- a/src/edu/wright/cs/raiderplanner/view/CreateAccount.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/CreateAccount.fxml
@@ -33,7 +33,7 @@ stylesheets="@../content/stylesheet.css" xmlns="http://javafx.com/javafx/8" xmln
                         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                     </HBox.margin>
                 </TextField>
-                <CheckBox fx:id="famLast" mnemonicParsing="false" selected="true" text="Family name last?" GridPane.rowIndex="1">
+                <CheckBox fx:id="famLast" mnemonicParsing="false" onMouseClicked="#toggleButton" selected="true" text="Family name last?" GridPane.rowIndex="1">
                     <HBox.margin>
                         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                     </HBox.margin>
@@ -69,7 +69,7 @@ stylesheets="@../content/stylesheet.css" xmlns="http://javafx.com/javafx/8" xmln
                         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                     </HBox.margin>
                 </Button>
-                <Button cancelButton="true" mnemonicParsing="false" onAction="#handleQuit" prefHeight="31.0" prefWidth="90.0" text="Quit">
+                <Button fx:id="cancelButton" defaultButton = "false" mnemonicParsing="false" onAction="#handleQuit" prefHeight="31.0" prefWidth="90.0" text="Quit">
                     <HBox.margin>
                         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                     </HBox.margin>


### PR DESCRIPTION
The user was previously unable to use the keyboard to submit on the account creation screen

While the account creation screen was technically functional, the keyboard did not behave intuitively. The user was unable to press enter while the submit button was focused to submit the form. The same holds true for the quit button. The user now is able to navigate through the entire account creation process using only the keyboard.