### PR TITLE
Issue 362 - Set Profile Dialog Moved to the Bottom of Study Profile Page

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/MenuController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/MenuController.java
@@ -50,12 +50,14 @@ import javafx.embed.swing.SwingFXUtils;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
+import javafx.scene.Parent;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.Button;
@@ -784,8 +786,15 @@ public class MenuController implements Initializable {
 					if (!row.isEmpty() && event.getButton() == MouseButton.PRIMARY
 							&& event.getClickCount() == 2) {
 						try {
-							MainController.ui.studyProfileDetails(row.getItem());
 							this.main();
+							StudyProfileController spc = new StudyProfileController(row.getItem(),
+									this);
+							// Load in the .fxml file:
+							FXMLLoader loader = new FXMLLoader(getClass().getResource(
+									"/edu/wright/cs/raiderplanner/view/StudyProfile.fxml"));
+							loader.setController(spc);
+							Parent root = loader.load();
+							this.mainContent.add(root,0,25);
 						} catch (IOException e1) {
 							UiManager.reportError("Unable to open View file");
 						}

--- a/src/edu/wright/cs/raiderplanner/controller/StudyProfileController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/StudyProfileController.java
@@ -36,6 +36,7 @@ import java.util.ResourceBundle;
  */
 public class StudyProfileController implements Initializable {
 	private StudyProfile profile;
+	private MenuController mc;
 
 	// Labels:
 	@FXML private Label title;
@@ -54,6 +55,7 @@ public class StudyProfileController implements Initializable {
 	public void setCurrent() {
 		MainController.getSpc().getPlanner().setCurrentStudyProfile(this.profile);
 		this.setCurrent.setDisable(true);
+		mc.main();
 	}
 
 	/**
@@ -69,6 +71,14 @@ public class StudyProfileController implements Initializable {
 	 */
 	public StudyProfileController(StudyProfile profile) {
 		this.profile = profile;
+	}
+
+	/**
+	 * Constructor for the StudyProfileController.
+	 */
+	public StudyProfileController(StudyProfile profile,MenuController mc) {
+		this.profile = profile;
+		this.mc = mc;
 	}
 
 	@Override

--- a/src/edu/wright/cs/raiderplanner/view/StudyProfile.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/StudyProfile.fxml
@@ -33,12 +33,6 @@
                        text="# extension applications."/>
             </children>
         </VBox>
-        <Button defaultButton="true" mnemonicParsing="false" onAction="#handleClose" prefHeight="31.0" prefWidth="69.0"
-                text="OK" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="2">
-            <GridPane.margin>
-                <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
-            </GridPane.margin>
-        </Button>
         <Button fx:id="setCurrent" layoutX="531.0" layoutY="141.0" mnemonicParsing="false" onAction="#setCurrent"
                 prefHeight="31.0" prefWidth="119.0" styleClass="set-button" text="Set as current" GridPane.rowIndex="2">
             <GridPane.margin>


### PR DESCRIPTION
The study profile dialog no longer pops up on the study profile page, instead the dialog appears below the list of available profiles when a user double clicks a profile in the observable list. The 'OK' button was removed from the dialog. In the notifications tab, when a new study profile is loaded you can still click on the notification to bring up the dialog and set your default profile. 
Before:
![beforedialog](https://user-images.githubusercontent.com/10665041/48512832-6bd11300-e828-11e8-925b-74784eb18f76.jpg)
New location of set current profile button and information:
![362](https://user-images.githubusercontent.com/10665041/47968993-6d882300-e03f-11e8-8db8-378cfa517384.jpg)
Old Dialog still opens when a user left clicks the profile creation statement from the notifications drop down:
![olddialog](https://user-images.githubusercontent.com/10665041/47969010-9ad4d100-e03f-11e8-89db-72d03f6e2917.jpg)
