### PR TITLE
closes program only when initial file saving is canceled or exited. Name and email was added to authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Nathaniel C Crossman <crossman.4@wright.edu>
 Gabriel Dodds <dodds.26@wright.edu>
 Randy Forte <forterandy@outlook.com>
 Aaron Hammer <hammer.21@wright.edu>
+Dominick Hatton <hatton.24@wright.edu>
 Peter Haviland <haviland.4@wright.edu>
 Rachel Hill <hill.382@wright.edu>
 Andy Hulett <hulett.4@wright.edu>

--- a/src/edu/wright/cs/raiderplanner/view/UiManager.java
+++ b/src/edu/wright/cs/raiderplanner/view/UiManager.java
@@ -95,6 +95,8 @@ public class UiManager {
 			"/edu/wright/cs/raiderplanner/view/Startup.fxml");
 	private URL settingsFxml = getClass().getResource(
 			"/edu/wright/cs/raiderplanner/view/Settings.fxml");
+	
+	private static int setupCount = 0;
 
 	/**
 	 * Displays a 'Create Account' window and handles the creation of a new Account object.
@@ -172,7 +174,9 @@ public class UiManager {
 		FXMLLoader loader = new FXMLLoader(mainMenuFxml);
 		loader.setController(UiManager.mc);
 		Parent root = loader.load();
-
+		setupCount++;//prevents saving file closing the program when the main menu has been opened. 
+		//so if the cancel or exit are pressed in saving file, only closes the program during first account setup
+		
 		// Set the scene with the SettingsFxml:
 		mainStage.getScene().setRoot(root);
 		mainStage.setTitle("RaiderPlanner");
@@ -552,6 +556,8 @@ public class UiManager {
 		}
 		fileChooser.setInitialDirectory(savesFolder);
 		File file = fileChooser.showSaveDialog(mainStage);
+		if(file == null && setupCount == 0)System.exit(0);//allows program to close if cancel or exit are pressed
+		setupCount++;//prevents the cancel button from closing the program except for initial setup.
 		return file;
 	}
 


### PR DESCRIPTION
Name added to authors file. During first account setup, if the cancel or exit button are pressed it will now close the program instead of
continuing to the dash board. But, If the user is already in the dash
board and tries to create an account, the file chooser cancel or exit
will not close the program This fixes Issue #389