### PR TITLE
Added dedicated help page to RaiderPlanner (Issue #240)

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/MainController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/MainController.java
@@ -29,6 +29,13 @@ import edu.wright.cs.raiderplanner.model.Notification;
 import edu.wright.cs.raiderplanner.model.Settings;
 import edu.wright.cs.raiderplanner.model.StudyPlanner;
 import edu.wright.cs.raiderplanner.view.UiManager;
+import javafx.scene.Scene;
+import javafx.scene.control.Accordion;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TitledPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
 
 import java.awt.Desktop;
 import java.io.BufferedInputStream;
@@ -416,18 +423,69 @@ public class MainController {
 	}
 
 	/**
-	 * Launches the default browser to display a URI.
-	 */
-	public static void openBrowser() {
-		if (Desktop.isDesktopSupported()) {
-			try {
-				Desktop.getDesktop().browse(new URI("https://rsanchez-wsu.github.io/RaiderPlanner/"));
-			} catch (IOException e) {
-				UiManager.reportError("Default browser not found or failed to launch");
-			} catch (URISyntaxException e) {
-				UiManager.reportError("Invaild URI syntax");
+	* Launches the default browser to display a URI.
+	*/
+	public static void openHelpPage() {
+		final Button site = new Button("Website");
+		final Button pdf = new Button("user-manual");
+		Label tab1 = new Label("RaiderPlanner is an application based off of the Pear Planner "
+				+ "to help students keep"
+				+ " track of assignments and exams, allowing them to achieve their full academic"
+				+ " potential. "
+				+ "Current features include a calendar, an alarm, and a Gantt diagram generator"
+				+ " to keep track of progress");
+		Label tab2 = new Label("How to use RaiderPlanner in 3 easy steps:"
+				+ "\n" + "1: Enter valid information for all the fields on the startup page. "
+						+ "All other information is optional." + "\n"
+				+ "2: Choose the name of the file you want to save to." + "\n"
+				+ "3: To unlock all the other features RaiderPlanner has to offer, click the"
+				+ " import hub file button from the menu on the left"
+				+  "\nNeed more help? Open up the user manual or RaiderPlanner Website here");
+		Label tab3 = new Label("If you want, you can contribute to RaiderPlanner on github at"
+				+ " the this address: https://github.com/rsanchez-wsu/RaiderPlanner"
+				+ "\n" + "Planned features include a graduation planner, Pilot integration, and a "
+				+ "schedule sharing feature");
+		tab1.setWrapText(true);
+		tab2.setWrapText(true);
+		tab3.setWrapText(true);
+		VBox splitter = new VBox();
+		splitter.getChildren().add(tab2);
+		splitter.getChildren().add(pdf);
+		splitter.getChildren().add(site);
+		TitledPane t1 = new TitledPane("What is RaiderPlanner?",tab1);
+		TitledPane t2 = new TitledPane("Getting Started",splitter);
+		TitledPane t3 = new TitledPane("Whats Next?",tab3);
+		Accordion root = new Accordion();
+		root.getPanes().addAll(t1, t2, t3);
+		Stage newStage = new Stage();
+		newStage.setTitle("Raider Helper");
+		Scene scene = new Scene(root,400,300);
+		newStage.setScene(scene);
+		newStage.show();
+
+		pdf.setOnAction((event) -> {
+			if (Desktop.isDesktopSupported()) {
+				try {
+					File myFile = new
+							File("Final Documents/"
+									+ "User Manual.pdf");
+					Desktop.getDesktop().open(myFile);
+				} catch (IOException ex) {
+					System.out.println("Error: user-manual not found");
+				}
 			}
-		}
+		});
+		site.setOnAction((event) -> {
+			if (Desktop.isDesktopSupported()) {
+				try {
+					File myFile = new
+							File("docs/index.html");
+					Desktop.getDesktop().open(myFile);
+				} catch (IOException ex) {
+					System.out.println("Error: Website not found");
+				}
+			}
+		});
 	}
 
 	/**

--- a/src/edu/wright/cs/raiderplanner/controller/MenuController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/MenuController.java
@@ -1559,8 +1559,8 @@ public class MenuController implements Initializable {
 	/**
 	 * Handles the 'Help' event.
 	 */
-	public void openBrowser() {
-		MainController.openBrowser();
+	public void openHelpPage() {
+		MainController.openHelpPage();
 	}
 
 	/**

--- a/src/edu/wright/cs/raiderplanner/view/MainMenu.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/MainMenu.fxml
@@ -171,7 +171,7 @@
       	                                 <Image url="/edu/wright/cs/raiderplanner/content/help.png" />
       	                             </image>
       	                         </ImageView>
-      	                         <Button fx:id="help" onAction="#openBrowser" style="-fx-background-color: transparent; -fx-text-fill:white; -fx-cursor: hand;" text="Help" />
+      	                         <Button fx:id="help" onAction="#openHelpPage" style="-fx-background-color: transparent; -fx-text-fill:white; -fx-cursor: hand;" text="Help" />
       </children>
    	                     </HBox>
    </children>


### PR DESCRIPTION
Rather than just opening the website with the help button, now a
dedicated gui offering help to the user is opened from Raider Planner.
The website and a user manual can easily be accessed from the gui should
this be needed
![tab2](https://user-images.githubusercontent.com/31524352/48792515-74ab6400-ecc2-11e8-8f5a-daba0b26f4a9.PNG)
![tab3](https://user-images.githubusercontent.com/31524352/48792516-74ab6400-ecc2-11e8-9d12-f7060d5f1759.PNG)
![mainview](https://user-images.githubusercontent.com/31524352/48792517-74ab6400-ecc2-11e8-9df6-2f1bfebcb240.PNG)
![tab1](https://user-images.githubusercontent.com/31524352/48792518-74ab6400-ecc2-11e8-8bbf-81e91f041dcb.PNG)



