### PR TITLE
Changed chat feature to give date and time of message

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/ChatController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/ChatController.java
@@ -32,6 +32,9 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 /**
  * This is a class to handle the code for the chat feature.
  * @author MichaelPantoja
@@ -85,8 +88,11 @@ public class ChatController {
 	 */
 	public static void sendButtonAction(String userName) {
 		sendButton.setOnAction((ActionEvent exception1) -> {
+			DateTimeFormatter date = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+			LocalDateTime time = LocalDateTime.now();
 			if (!(tfMessageToSend.getText().equals(""))) {
-				msgArea.appendText(userName + ": " + tfMessageToSend.getText() + "\n");
+				msgArea.appendText(userName + ": " + tfMessageToSend.getText());
+				msgArea.appendText("\t\t\t" + date.format(time) + "\n");
 				tfMessageToSend.setText("");
 			}
 		});


### PR DESCRIPTION
This change appends the date and time to the end of each message sent in the chat feature. 
This provides extra utility to the chat feature. 

Fixes Issue #419 

This is the chat window before changes:

![image](https://user-images.githubusercontent.com/42789195/48678157-66880700-eb4d-11e8-86aa-54f56e05aeee.png)


This is the chat window after changes:
![image](https://user-images.githubusercontent.com/42789195/48678139-2aed3d00-eb4d-11e8-8673-c78c194c1514.png)
