### PR TITLE
Changed chat feature to give date and time of message

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/ChatController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/ChatController.java
@@ -32,6 +32,9 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 /**
  * This is a class to handle the code for the chat feature.
  * @author MichaelPantoja
@@ -80,13 +83,16 @@ public class ChatController {
 	/**
 	 *  This will take in the action of when the send button is pressed. If a user sends a message,
 	 *  the line of text will append to the chat log so the user can see what they sent. It follows
-	 *  the format of USER: sentence.
+	 *  the format of USER: sentence time/date.
 	 *  The text box with the user input will be set back to blank after a message is sent.
 	 */
 	public static void sendButtonAction(String userName) {
 		sendButton.setOnAction((ActionEvent exception1) -> {
+			DateTimeFormatter date = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+			LocalDateTime time = LocalDateTime.now();
 			if (!(tfMessageToSend.getText().equals(""))) {
-				msgArea.appendText(userName + ": " + tfMessageToSend.getText() + "\n");
+				msgArea.appendText(userName + ": " + tfMessageToSend.getText());
+				msgArea.appendText("\t\t\t" + date.format(time) + "\n");
 				tfMessageToSend.setText("");
 			}
 		});


### PR DESCRIPTION
This change appends the date and time to the end of each
message sent in the chat feature. This provides extra
utility to the chat feature.

This pull request is same as request #423 with changes made to the commit message.

Fixes #419

This is the chat window before changes:

![image](https://user-images.githubusercontent.com/42789195/48779564-d90bfa80-eca5-11e8-89d1-6ff1f4d7b3fb.png)


This is the chat window after changes:

![image](https://user-images.githubusercontent.com/42789195/48779579-e32df900-eca5-11e8-8daf-ac57e4b8cc5f.png)
