### PR TITLE
Fixes For Issues #441, #450, #455

### DIFF
--- a/docs/assets/css/untitled.css
+++ b/docs/assets/css/untitled.css
@@ -2,7 +2,7 @@
   background-color: rgb(122,86,83);
 }
 
-.doanload {
+.download {
   color: black;
 }
 

--- a/src/edu/wright/cs/raiderplanner/content/stylesheet.css
+++ b/src/edu/wright/cs/raiderplanner/content/stylesheet.css
@@ -13,7 +13,7 @@
 }
 
 .set-button {
-    -fx-base: #CEA052;
+    -fx-base: #4aea95;
 }
 
 .back-button {
@@ -59,7 +59,7 @@
 }
 
 .current-item {
-    -fx-background-color: #CEA052;
+    -fx-background-color: #4aea95;
 }
 
 .print-button {

--- a/src/edu/wright/cs/raiderplanner/view/Activity.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/Activity.fxml
@@ -138,7 +138,8 @@
                 </HBox>
             </children>
         </VBox>
-        <ComboBox fx:id="quantityType" onAction="#handleChange" prefHeight="31.0" prefWidth="531.0" promptText="Quantity type" GridPane.columnIndex="1" GridPane.rowIndex="2">
+ 			<ComboBox fx:id="quantityType" onAction="#handleChange" prefHeight="31.0" prefWidth="531.0"
+                  promptText="Activity Type" GridPane.columnIndex="1" GridPane.rowIndex="2">
             <GridPane.margin>
                 <Insets bottom="5.0" left="10.0" right="10.0" top="5.0" />
             </GridPane.margin>

--- a/src/edu/wright/cs/raiderplanner/view/CreateAccount.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/CreateAccount.fxml
@@ -8,10 +8,10 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.collections.FXCollections ?>
 <GridPane fx:id="pane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" 
-prefHeight="232.0" prefWidth="550.0" 
+prefHeight="232.0" prefWidth="565.0" 
 stylesheets="@../content/stylesheet.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
-        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="300.0" />
     </columnConstraints>
     <rowConstraints>
         <RowConstraints maxHeight="60.0" minHeight="10.0" prefHeight="60.0" vgrow="SOMETIMES" />

--- a/src/edu/wright/cs/raiderplanner/view/Requirement.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/Requirement.fxml
@@ -120,7 +120,9 @@
         </HBox>
         <HBox alignment="TOP_CENTER" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="2" GridPane.valignment="CENTER"> 
             <children>
-                <ComboBox fx:id="quantityType" onAction="#handleChange" prefHeight="31.0" prefWidth="242.0" promptText="Quantity type" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="2" GridPane.valignment="TOP">
+                <ComboBox fx:id="quantityType" onAction="#handleChange" prefHeight="31.0" prefWidth="242.0"
+                          promptText="Requirement Type" GridPane.columnIndex="1" GridPane.halignment="CENTER"
+                          GridPane.rowIndex="2" GridPane.valignment="TOP">
                     <GridPane.margin>
                         <Insets bottom="10.0" left="10.0" right="10.0" top="5.0" />
                     </GridPane.margin>

--- a/src/edu/wright/cs/raiderplanner/view/Task.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/Task.fxml
@@ -119,7 +119,9 @@
         </HBox>
         <HBox alignment="CENTER" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="2" GridPane.valignment="CENTER">
             <children>
-                <ComboBox fx:id="taskType" onAction="#handleChange" prefHeight="31.0" prefWidth="237.0" promptText="Task type" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="2" GridPane.valignment="CENTER">
+                <ComboBox fx:id="taskType" onAction="#handleChange" prefHeight="31.0" prefWidth="237.0"
+                          promptText="Task Type" GridPane.columnIndex="1" GridPane.halignment="CENTER"
+                          GridPane.rowIndex="2" GridPane.valignment="CENTER">
                     <GridPane.margin>
                         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                     </GridPane.margin>

--- a/src/edu/wright/cs/raiderplanner/view/UiManager.java
+++ b/src/edu/wright/cs/raiderplanner/view/UiManager.java
@@ -112,7 +112,7 @@ public class UiManager {
 		Parent root = loader.load();
 		// Set the scene:
 		Stage stage = new Stage();
-		stage.setScene(new Scene(root, 550, 232));
+		stage.setScene(new Scene(root, 565, 232));
 		stage.setTitle("Create Account");
 		stage.resizableProperty().setValue(false);
 		stage.getIcons().add(icon);


### PR DESCRIPTION
Issue #441 Ensure the createAccount pop-up is not to wide

Adjusted the width of the createAccount pop-up from 550px to 565px so
that no text is cut off. Change applied in both CreateAccount.fxml and
UiManager.java.

Issue #450  Imposed Label Uniformity in Type Combo Boxes

Changed the labels of the type combo boxes in Requirement, Activity and
Task to match the parent pop-up. Changes made to Activity.fxml,
Requirement.fxml, and Task.fxml.

Issue #455 Altered the background color for a completed task/set button + small typo fix

Changed the task complete color (#CEA052) to (#4aea95). Change made to
stylesheet.css.

Also fixed a small typo that I discovered in
docs/assets/css/untitled.css. Changed 'doanload' to 'download'.
