### PR TITLE
Fix error dialogue box at account creation - Issue #22

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Aashish Bharadwaj <aashish.bharadwaj01@gmail.com>
 Alena Brand <brand.18@wright.edu>
 Nathaniel C Crossman <crossman.4@wright.edu>
 Gabriel Dodds <dodds.26@wright.edu>
+Elizabeth Farr <farr.16@wright.edu>
 Randy Forte <forterandy@outlook.com>
 Aaron Hammer <hammer.21@wright.edu>
 Dominick Hatton <hatton.24@wright.edu>

--- a/src/edu/wright/cs/raiderplanner/controller/AccountController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/AccountController.java
@@ -23,6 +23,7 @@ package edu.wright.cs.raiderplanner.controller;
 
 import edu.wright.cs.raiderplanner.model.Account;
 import edu.wright.cs.raiderplanner.model.Person;
+import edu.wright.cs.raiderplanner.view.UiManager;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -88,7 +89,7 @@ public class AccountController implements Initializable {
 	 * @return true if the user entered a valid salutation.
 	 */
 	public boolean validateSalutation() {
-		if (!Person.validSalutation(this.salutation.getSelectionModel().getSelectedItem().trim())) {
+		if (this.salutation.getValue() == null) {
 			return false;
 		} else {
 			this.salutation.setStyle("");
@@ -199,9 +200,6 @@ public class AccountController implements Initializable {
 			Stage stage = (Stage) this.submit.getScene().getWindow();
 			stage.close();
 		} else if (!validSuccess) {
-			//***Alert does not successfully display.
-			//OK button should also be red when hovered over
-			//Possible fix: change invalidInputAlert to UiManager display error
 			invalidInputAlert.setHeaderText("Invalid Entries");
 			invalidInputAlert.setContentText(invalidMessage);
 			invalidInputAlert.showAndWait();
@@ -237,6 +235,7 @@ public class AccountController implements Initializable {
 		submit.setOnAction(e -> {
 			if (submit.isFocused()) {
 				handleSubmit();
+				System.out.println("Hello there is oops");
 			}
 		});
 	}

--- a/src/edu/wright/cs/raiderplanner/controller/AccountController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/AccountController.java
@@ -122,7 +122,7 @@ public class AccountController implements Initializable {
 	 * @return True if the user entered a valid email.
 	 */
 	public boolean validateEmail() {
-		if (this.email.getText().trim().isEmpty()
+		if (!this.email.getText().trim().isEmpty()
 				|| Person.validEmail(this.email.getText().trim())) {
 			this.email.setStyle("");
 			return true;

--- a/src/edu/wright/cs/raiderplanner/controller/AccountController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/AccountController.java
@@ -175,10 +175,6 @@ public class AccountController implements Initializable {
 			invalidMessage += "Please enter a valid W Number\n";
 			validSuccess = false;
 		}
-		if (!validateName()) {
-			invalidMessage += "Please enter a valid name\n";
-			validSuccess = false;
-		}
 		if (!validateEmail()) {
 			invalidMessage += "Please enter a valid email\n";
 			validSuccess = false;
@@ -235,7 +231,6 @@ public class AccountController implements Initializable {
 		submit.setOnAction(e -> {
 			if (submit.isFocused()) {
 				handleSubmit();
-				System.out.println("Hello there is oops");
 			}
 		});
 	}

--- a/src/edu/wright/cs/raiderplanner/controller/AccountController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/AccountController.java
@@ -199,6 +199,9 @@ public class AccountController implements Initializable {
 			Stage stage = (Stage) this.submit.getScene().getWindow();
 			stage.close();
 		} else if (!validSuccess) {
+			//***Alert does not successfully display.
+			//OK button should also be red when hovered over
+			//Possible fix: change invalidInputAlert to UiManager display error
 			invalidInputAlert.setHeaderText("Invalid Entries");
 			invalidInputAlert.setContentText(invalidMessage);
 			invalidInputAlert.showAndWait();


### PR DESCRIPTION
When the user entered incorrect information or left all boxes blank, a dialogue box would not correctly pop up, and errors could be seen in the terminal. Several things prevented the error window from displaying, and all were fixed. Unnecessary code checking the validity of First/Last Name was removed as a user is not required to enter it.